### PR TITLE
[PATCH] split the DQMC_Read_Cfg into two functions

### DIFF
--- a/SRC/dqmc_cfg.F90
+++ b/SRC/dqmc_cfg.F90
@@ -611,6 +611,33 @@ contains
     ! =========
     !
     type(config), intent(inout)  :: cfg          ! configuration
+    character(len=256)           :: iname
+    integer                      :: status
+
+    ! Fetch input file name from command line
+    call get_command_argument(1, iname, STATUS=status)
+    if (status > 0) then
+      call DQMC_Error("failed to retrieve input file argument", 0)
+    elseif (status == -1) then
+      call DQMC_Error("String 'iname' is too small to hold input file name, recompile me with a larger ifile!", 0)
+    end if
+
+    call DQMC_Read_ConfigFile(cfg, iname)
+
+  end subroutine DQMC_Read_Config
+
+  !---------------------------------------------------------------------!
+
+  subroutine DQMC_Read_ConfigFile(cfg, iname)
+    !
+    ! Purpose
+    ! =======
+    !    This subrotine reads in parameters from a config file.
+    !
+    ! Arguments
+    ! =========
+    !
+    type(config), intent(inout)  :: cfg          ! configuration
 
     ! ... Local Variable ...
     integer                :: ios, pos, line, j, id
@@ -620,17 +647,9 @@ contains
     type(Param), pointer   :: curr 
     integer, parameter     :: funit = 10
     character(len=60)      :: iname
-    integer                :: IPT, status
+    integer                :: IPT_T
 
     ! ... Executable ...
-
-    ! Fetch input file name from command line
-    call get_command_argument(1, iname, STATUS=status)
-    if (status > 0) then
-       call DQMC_Error("failed to retrieve input file argument", 0)
-    elseif (status == -1) then
-       call DQMC_Error("String 'iname' is too small to hold input file name, recompile me with a larger ifile!", 0)
-    end if
 
     ! Open input file
     call DQMC_open_file(iname, 'old', IPT)
@@ -742,7 +761,7 @@ contains
        end if
     end do
 
-  end subroutine DQMC_Read_Config
+  end subroutine DQMC_Read_ConfigFile
 
   !---------------------------------------------------------------------!
   ! Access functions 


### PR DESCRIPTION
This would add more flexibility, because the filename can be given directly as string or as command line argument.